### PR TITLE
fix: time.Time argument implements MarshalJSON - is serializable

### DIFF
--- a/pkg/internal/asttools/asttools.go
+++ b/pkg/internal/asttools/asttools.go
@@ -52,6 +52,8 @@ func IsSerializable(t types.Type) (bool, string) {
 				return true, "is a protobuf message"
 			}
 		}
+	} else if named, ok := t.Underlying().(*types.Named); ok {
+		return IsSerializable(named)
 	}
 
 	switch t := t.(type) {

--- a/test/example.go
+++ b/test/example.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"go.temporal.io/sdk/client"
 	worker "go.temporal.io/sdk/worker"
@@ -71,6 +72,10 @@ func HelloWorldWorkflow(ctx workflow.Context, name string) (string, error) {
 
 	// too many arguments
 	errList = append(errList, workflow.ExecuteActivity(ctx, act.Greet, name, "extra").Get(ctx, &result))
+
+	// too many arguments, it's a time.Time that has all fields private, but implements MarshalJSON
+	ti := time.Now()
+	errList = append(errList, workflow.ExecuteActivity(ctx, act.Greet, name, ti).Get(ctx, &result))
 
 	// too few arguments
 	errList = append(errList, workflow.ExecuteActivity(ctx, act.Greet).Get(ctx, &result))


### PR DESCRIPTION
fixes: 
* `time.Time` argument implements `MarshalJSON` - should not be considered unserializable, but was reported as not serializable.
* naming the argument that looks wrong, if it has a name
* reusing `isSerializable` on the entire argument, not just its fields